### PR TITLE
Add MetaTrader5 stub and update docs for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ AI_Trading_Bot_Web/
 
 - Python 3.8+
 - Flask
-- MetaTrader5 (package Python)
+- (Pilihan) Pakej MetaTrader5 untuk sambungan sebenar
 - MT4/MT5 dipasang di Windows
 
 - Sambungan ke terminal MT5 (sedia log masuk akaun demo/real)
@@ -50,19 +50,25 @@ AI_Trading_Bot_Web/
 
 🔧 Cara Pasang & Jalankan
 
-1. Pasang pakej keperluan:
+1. Pasang pakej keperluan asas:
 
 bash
 pip install -r requirements.txt
 
 
-2. Jalankan server Flask:
+2. (Opsyenal) Pasang `MetaTrader5` jika mahu sambungan sebenar:
+
+bash
+pip install MetaTrader5
+
+
+3. Jalankan server Flask:
 
 bash
 python app.py
 
 
-3. Buka browser:
+4. Buka browser:
 
 
 http://localhost:5000

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template, request, redirect, url_for
+from trading.bot_controller import BotController
+
+app = Flask(__name__)
+bot = BotController()
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        action = request.form.get('action')
+        if action == 'start':
+            bot.start()
+        elif action == 'stop':
+            bot.stop()
+        elif action == 'save':
+            symbol = request.form.get('symbol')
+            lot = float(request.form.get('lot', 0))
+            sl = float(request.form.get('sl', 0))
+            tp = float(request.form.get('tp', 0))
+            bot.update_settings(symbol, lot, sl, tp)
+        return redirect(url_for('index'))
+
+    return render_template(
+        'index.html',
+        bot_status=bot.status,
+        settings=bot.settings,
+        logs=bot.logs,
+    )
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3.0
+# MetaTrader5>=5.0.45  # Pasang secara manual jika diperlukan

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #f8f9fa;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ms">
+<head>
+    <meta charset="UTF-8">
+    <title>AI Trading Bot Web Panel</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="container py-4">
+    <h1 class="mb-4">AI Trading Bot Web Panel</h1>
+
+    <section class="mb-4">
+        <h2>Status Bot: <span class="badge bg-secondary">{{ bot_status }}</span></h2>
+        <form method="post">
+            {% if bot_status == 'Berjalan' %}
+            <button type="submit" name="action" value="stop" class="btn btn-danger">Henti Bot</button>
+            {% else %}
+            <button type="submit" name="action" value="start" class="btn btn-success">Mula Bot</button>
+            {% endif %}
+        </form>
+    </section>
+
+    <section class="mb-4">
+        <h2>Tetapan Dagangan</h2>
+        <form method="post" class="row g-3">
+            <input type="hidden" name="action" value="save">
+            <div class="col-md-3">
+                <label class="form-label">Simbol</label>
+                <select name="symbol" class="form-select">
+                    <option value="XAUUSD" {% if settings.symbol == 'XAUUSD' %}selected{% endif %}>XAUUSD</option>
+                    <option value="US30" {% if settings.symbol == 'US30' %}selected{% endif %}>US30</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Lot</label>
+                <input type="number" step="0.01" name="lot" value="{{ settings.lot }}" class="form-control" required>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Stop Loss</label>
+                <input type="number" step="0.1" name="sl" value="{{ settings.sl }}" class="form-control">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Take Profit</label>
+                <input type="number" step="0.1" name="tp" value="{{ settings.tp }}" class="form-control">
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Simpan Tetapan</button>
+            </div>
+        </form>
+    </section>
+
+    <section>
+        <h2>Log Aktiviti</h2>
+        <ul class="list-group">
+            {% for log in logs %}
+            <li class="list-group-item">{{ log }}</li>
+            {% else %}
+            <li class="list-group-item">Tiada log lagi.</li>
+            {% endfor %}
+        </ul>
+    </section>
+</body>
+</html>

--- a/trading/bot_controller.py
+++ b/trading/bot_controller.py
@@ -1,0 +1,65 @@
+"""Controller untuk logik AI Trading Bot."""
+
+from __future__ import annotations
+
+import datetime
+from typing import List
+
+try:
+    import MetaTrader5 as mt5  # type: ignore
+    MT5_AVAILABLE = True
+except Exception:  # pragma: no cover - pakej mungkin tiada
+    from . import mt5_stub as mt5  # type: ignore
+    MT5_AVAILABLE = False
+
+
+class BotController:
+    """Urus mula/henti bot serta tetapan dagangan."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self.settings = {
+            "symbol": "XAUUSD",
+            "lot": 0.01,
+            "sl": 0.0,
+            "tp": 0.0,
+        }
+        self.logs: List[str] = []
+
+    @property
+    def status(self) -> str:
+        return "Berjalan" if self._running else "Berhenti"
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.logs.insert(0, f"[{timestamp}] {message}")
+
+    def start(self) -> None:
+        if self._running:
+            self.log("Bot sudah berjalan.")
+            return
+        if not mt5.initialize():
+            self.log("Gagal sambung ke MT5.")
+            return
+        if not MT5_AVAILABLE:
+            self.log("Pakej MetaTrader5 tidak dipasang; menggunakan mod simulasi.")
+        self._running = True
+        self.log("Bot dimulakan.")
+        # TODO: Tambah logik sambungan ke MT4/MT5 dan AI di sini
+
+    def stop(self) -> None:
+        if not self._running:
+            self.log("Bot tidak berjalan.")
+            return
+        mt5.shutdown()
+        self._running = False
+        self.log("Bot dihentikan.")
+
+    def update_settings(self, symbol: str, lot: float, sl: float, tp: float) -> None:
+        self.settings.update({
+            "symbol": symbol,
+            "lot": lot,
+            "sl": sl,
+            "tp": tp,
+        })
+        self.log("Tetapan dagangan dikemas kini.")

--- a/trading/mt5_stub.py
+++ b/trading/mt5_stub.py
@@ -1,0 +1,15 @@
+"""Modul stub MetaTrader5 untuk pembangunan tanpa pakej sebenar."""
+
+from __future__ import annotations
+
+
+def initialize() -> bool:
+    """Simulasi sambungan ke terminal MT5."""
+    print("[MT5Stub] initialize dipanggil")
+    return True
+
+
+def shutdown() -> bool:
+    """Simulasi penutupan sambungan."""
+    print("[MT5Stub] shutdown dipanggil")
+    return True


### PR DESCRIPTION
## Summary
- add MetaTrader5 stub so bot can run without the real package
- mark MetaTrader5 as optional in requirements and document manual installation
- update bot controller to initialize/shutdown MT5 and log simulation mode

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py trading/bot_controller.py trading/mt5_stub.py`
- `python app.py`
- `python - <<'PY'\nfrom trading.bot_controller import BotController\nbot = BotController()\nbot.start()\nbot.stop()\nprint(bot.logs[:2])\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68c8195b7c3c832b99c7b00c2540019c