### PR TITLE
Validate trade settings input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+trading/config.json

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Satu aplikasi *AI Trading Bot* yang boleh dikawal melalui *antara muka web*. Bot
 2. ⚙ *Tetapan Dagangan*
    - Pilih simbol: XAU/USD, US30
    - Tetapkan saiz lot, Stop Loss, Take Profit
+   - Tetapan disimpan ke `trading/config.json`
 
 3. 📋 *Log Aktiviti*
    - Lihat semua aktiviti bot: trade dibuka, status sambungan, ralat
@@ -41,7 +42,7 @@ AI_Trading_Bot_Web/
 
 - Python 3.8+
 - Flask
-- MetaTrader5 (package Python)
+- (Pilihan) Pakej MetaTrader5 untuk sambungan sebenar
 - MT4/MT5 dipasang di Windows
 
 - Sambungan ke terminal MT5 (sedia log masuk akaun demo/real)
@@ -50,19 +51,25 @@ AI_Trading_Bot_Web/
 
 🔧 Cara Pasang & Jalankan
 
-1. Pasang pakej keperluan:
+1. Pasang pakej keperluan asas:
 
 bash
 pip install -r requirements.txt
 
 
-2. Jalankan server Flask:
+2. (Opsyenal) Pasang `MetaTrader5` jika mahu sambungan sebenar:
+
+bash
+pip install MetaTrader5
+
+
+3. Jalankan server Flask:
 
 bash
 python app.py
 
 
-3. Buka browser:
+4. Buka browser:
 
 
 http://localhost:5000

--- a/app.py
+++ b/app.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from flask import Flask, render_template, request, redirect, url_for
+
+from trading.bot_controller import BotController
+
+app = Flask(__name__)
+bot = BotController()
+
+
+def _parse_float(value: Optional[str], default: float) -> float:
+    """Safely parse a float from form data, falling back to a default."""
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        action = request.form.get('action')
+        if action == 'start':
+            bot.start()
+        elif action == 'stop':
+            bot.stop()
+        elif action == 'save':
+            symbol = request.form.get('symbol') or bot.settings.get('symbol', '')
+            lot = _parse_float(request.form.get('lot'), bot.settings.get('lot', 0.0))
+            sl = _parse_float(request.form.get('sl'), bot.settings.get('sl', 0.0))
+            tp = _parse_float(request.form.get('tp'), bot.settings.get('tp', 0.0))
+            bot.update_settings(symbol, lot, sl, tp)
+        return redirect(url_for('index'))
+
+    return render_template(
+        'index.html',
+        bot_status=bot.status,
+        settings=bot.settings,
+        logs=bot.logs,
+    )
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3.0
+# MetaTrader5>=5.0.45  # Pasang secara manual jika diperlukan

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #f8f9fa;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ms">
+<head>
+    <meta charset="UTF-8">
+    <title>AI Trading Bot Web Panel</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="container py-4">
+    <h1 class="mb-4">AI Trading Bot Web Panel</h1>
+
+    <section class="mb-4">
+        <h2>Status Bot: <span class="badge bg-secondary">{{ bot_status }}</span></h2>
+        <form method="post">
+            {% if bot_status == 'Berjalan' %}
+            <button type="submit" name="action" value="stop" class="btn btn-danger">Henti Bot</button>
+            {% else %}
+            <button type="submit" name="action" value="start" class="btn btn-success">Mula Bot</button>
+            {% endif %}
+        </form>
+    </section>
+
+    <section class="mb-4">
+        <h2>Tetapan Dagangan</h2>
+        <form method="post" class="row g-3">
+            <input type="hidden" name="action" value="save">
+            <div class="col-md-3">
+                <label class="form-label">Simbol</label>
+                <select name="symbol" class="form-select">
+                    <option value="XAUUSD" {% if settings.symbol == 'XAUUSD' %}selected{% endif %}>XAUUSD</option>
+                    <option value="US30" {% if settings.symbol == 'US30' %}selected{% endif %}>US30</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Lot</label>
+                <input type="number" step="0.01" min="0.01" name="lot" value="{{ settings.lot }}" class="form-control" required>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Stop Loss</label>
+                <input type="number" step="0.1" min="0" name="sl" value="{{ settings.sl }}" class="form-control">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Take Profit</label>
+                <input type="number" step="0.1" min="0" name="tp" value="{{ settings.tp }}" class="form-control">
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Simpan Tetapan</button>
+            </div>
+        </form>
+    </section>
+
+    <section>
+        <h2>Log Aktiviti</h2>
+        <ul class="list-group">
+            {% for log in logs %}
+            <li class="list-group-item">{{ log }}</li>
+            {% else %}
+            <li class="list-group-item">Tiada log lagi.</li>
+            {% endfor %}
+        </ul>
+    </section>
+</body>
+</html>

--- a/trading/bot_controller.py
+++ b/trading/bot_controller.py
@@ -1,0 +1,120 @@
+"""Controller untuk logik AI Trading Bot."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import List
+
+try:
+    import MetaTrader5 as mt5  # type: ignore
+    MT5_AVAILABLE = True
+except Exception:  # pragma: no cover - pakej mungkin tiada
+    from . import mt5_stub as mt5  # type: ignore
+    MT5_AVAILABLE = False
+
+
+CONFIG_FILE = Path(__file__).with_name("config.json")
+ALLOWED_SYMBOLS = {"XAUUSD", "US30"}
+
+
+class BotController:
+    """Urus mula/henti bot serta tetapan dagangan."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self.settings = {
+            "symbol": "XAUUSD",
+            "lot": 0.01,
+            "sl": 0.0,
+            "tp": 0.0,
+        }
+        self.logs: List[str] = []
+        self.load_settings()
+
+    @property
+    def status(self) -> str:
+        return "Berjalan" if self._running else "Berhenti"
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.logs.insert(0, f"[{timestamp}] {message}")
+        # Kekalkan log terkini sahaja supaya memori tidak meningkat tanpa kawalan
+        if len(self.logs) > 200:
+            self.logs = self.logs[:200]
+
+    def _validate_symbol(self, symbol: str) -> str:
+        """Pastikan simbol yang diterima berada dalam senarai dibenarkan."""
+        if not symbol:
+            return self.settings["symbol"]
+        normalized = symbol.upper()
+        if normalized not in ALLOWED_SYMBOLS:
+            self.log(
+                f"Simbol {normalized} tidak disokong; menggunakan nilai sebelumnya."
+            )
+            return self.settings["symbol"]
+        return normalized
+
+    def _sanitize_numeric(self, value: float, fallback: float, label: str) -> float:
+        """Pastikan nilai numerik adalah sah dan tidak negatif."""
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            self.log(f"Nilai {label} tidak sah; menggunakan nilai sebelumnya.")
+            return fallback
+        if number < 0:
+            self.log(f"Nilai {label} tidak boleh negatif; menggunakan nilai sebelumnya.")
+            return fallback
+        return number
+
+    def start(self) -> None:
+        if self._running:
+            self.log("Bot sudah berjalan.")
+            return
+        if not mt5.initialize():
+            self.log("Gagal sambung ke MT5.")
+            return
+        if not MT5_AVAILABLE:
+            self.log("Pakej MetaTrader5 tidak dipasang; menggunakan mod simulasi.")
+        self._running = True
+        self.log("Bot dimulakan.")
+        # TODO: Tambah logik sambungan ke MT4/MT5 dan AI di sini
+
+    def stop(self) -> None:
+        if not self._running:
+            self.log("Bot tidak berjalan.")
+            return
+        mt5.shutdown()
+        self._running = False
+        self.log("Bot dihentikan.")
+
+    def update_settings(self, symbol: str, lot: float, sl: float, tp: float) -> None:
+        current = self.settings
+        updated_settings = {
+            "symbol": self._validate_symbol(symbol),
+            "lot": self._sanitize_numeric(lot, current["lot"], "lot"),
+            "sl": self._sanitize_numeric(sl, current["sl"], "SL"),
+            "tp": self._sanitize_numeric(tp, current["tp"], "TP"),
+        }
+        self.settings.update(updated_settings)
+        self.save_settings()
+        self.log("Tetapan dagangan dikemas kini.")
+
+    def load_settings(self) -> None:
+        """Muat tetapan daripada fail JSON jika wujud."""
+        if CONFIG_FILE.exists():
+            try:
+                with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                self.settings.update(data)
+            except Exception:
+                self.log("Gagal membaca fail konfigurasi.")
+
+    def save_settings(self) -> None:
+        """Simpan tetapan ke fail JSON."""
+        try:
+            with CONFIG_FILE.open("w", encoding="utf-8") as fh:
+                json.dump(self.settings, fh)
+        except Exception:
+            self.log("Gagal menulis fail konfigurasi.")

--- a/trading/mt5_stub.py
+++ b/trading/mt5_stub.py
@@ -1,0 +1,15 @@
+"""Modul stub MetaTrader5 untuk pembangunan tanpa pakej sebenar."""
+
+from __future__ import annotations
+
+
+def initialize() -> bool:
+    """Simulasi sambungan ke terminal MT5."""
+    print("[MT5Stub] initialize dipanggil")
+    return True
+
+
+def shutdown() -> bool:
+    """Simulasi penutupan sambungan."""
+    print("[MT5Stub] shutdown dipanggil")
+    return True


### PR DESCRIPTION
## Summary
- guard trade settings form submission against empty or invalid numeric values before updating the bot configuration
- validate symbols and numeric ranges in `BotController`, limiting the log list while preserving prior settings when input is invalid
- add UI input constraints for lot, stop loss, and take profit fields to prevent negative submissions

## Testing
- python -m py_compile app.py trading/bot_controller.py trading/mt5_stub.py
- python - <<'PY'
from trading.bot_controller import BotController

bot = BotController()
print('Initial settings:', bot.settings)

bot.update_settings('us30', 0.5, 50, 100)
print('After valid update:', bot.settings)

bot.update_settings('UNKNOWN', -1, 'abc', None)
print('After invalid update:', bot.settings)
print('Recent logs:', bot.logs[:4])
PY

------
https://chatgpt.com/codex/tasks/task_e_68c8195b7c3c832b99c7b00c2540019c